### PR TITLE
Add links to NIO mentions

### DIFF
--- a/src/components/About/AboutCard.js
+++ b/src/components/About/AboutCard.js
@@ -31,7 +31,7 @@ const AboutCard = () => {
     }
     : {
       highlights: [
-        <>Hello, I am <span className="text-accent">Yuting Zhou</span>, an <span className="text-accent">AI Agent Engineer</span> and <span className="text-accent">Business Planning Assistant Analyst</span> at <span className="text-accent">NIO</span>, holding an M.S. in Computer Science from <span className="text-accent">Rutgers University</span>.</>,
+        <>Hello, I am <span className="text-accent">Yuting Zhou</span>, an <span className="text-accent">AI Agent Engineer</span> and <span className="text-accent">Business Planning Assistant Analyst</span> at <span className="text-accent"><a className="nio-link" href="https://www.nio.com/" target="_blank" rel="noopener noreferrer">NIO</a></span>, holding an M.S. in Computer Science from <span className="text-accent">Rutgers University</span>.</>,
         <>I design and build <span className="text-accent">enterprise AI agent systems</span> for <span className="text-accent">manufacturing operations</span>, working across <span className="text-accent">LLMs &amp; RAG</span>, <span className="text-accent">workflow automation</span>, and <span className="text-accent">AI-driven decision support</span>.</>,
         <>Previously, I researched <span className="text-accent">NLP and LLMs</span> at the <span className="text-accent">Rutgers CAIT Lab</span>, and built <span className="text-accent">large-scale web applications</span> at Tenchii Digital Tech (a Tencent &times; Shanghai Metro joint venture).</>,
         <>Apart from coding, here are some activities I enjoy:</>

--- a/src/components/Experiences/ExperienceData.js
+++ b/src/components/Experiences/ExperienceData.js
@@ -36,6 +36,7 @@ export const timelines = [
                     en: "Shanghai NIO Automobile Co., Ltd.",
                     zh: "上海蔚来汽车有限公司"
                 },
+                companyUrl: "https://www.nio.com/",
                 duration: "06/2026 - Present",
                 description: {
                     en: [

--- a/src/components/Experiences/Experiences.js
+++ b/src/components/Experiences/Experiences.js
@@ -26,7 +26,13 @@ function ExperienceTimeline({ title, subtitle, data, icon: Icon }) {
                         icon={experience.icon ? <experience.icon /> : <Icon />}
                     >
                         <h3 className="vertical-timeline-element-title">{experience.title[locale]}</h3>
-                        <h5 className="vertical-timeline-element-subtitle">{experience.company[locale]}</h5>
+                        <h5 className="vertical-timeline-element-subtitle">
+                            {experience.companyUrl ? (
+                                <a className="nio-link" href={experience.companyUrl} target="_blank" rel="noopener noreferrer">
+                                    {experience.company[locale]}
+                                </a>
+                            ) : experience.company[locale]}
+                        </h5>
                         <ul className="experience-description">
                             {experience.description[locale].map((item, i) => (
                                 <li key={i}>{item}</li>

--- a/src/components/Home/Home2.js
+++ b/src/components/Home/Home2.js
@@ -40,7 +40,7 @@ function Home2() {
                 <>
                     I fell in love with programming and have stayed curious ever since.
                     <br /><br />
-                    Today I am an <b className="text-accent">AI Agent Engineer</b> at <b className="text-accent">NIO</b>, building <b className="text-accent">enterprise AI agent systems</b> for manufacturing operations with <b className="text-accent">LLMs &amp; RAG</b>, <b className="text-accent">workflow automation</b>, and <b className="text-accent">AI-driven decision support</b>.
+                    Today I am an <b className="text-accent">AI Agent Engineer</b> at <b className="text-accent"><a className="nio-link" href="https://www.nio.com/" target="_blank" rel="noopener noreferrer">NIO</a></b>, building <b className="text-accent">enterprise AI agent systems</b> for manufacturing operations with <b className="text-accent">LLMs &amp; RAG</b>, <b className="text-accent">workflow automation</b>, and <b className="text-accent">AI-driven decision support</b>.
                     <br /><br />
                     I work across the stack, from crafting <b className="text-accent">clean, responsive interfaces</b> to building <b className="text-accent">dependable back-end services</b>. I am comfortable with <b className="text-accent">databases, API design, and containerized deployments that scale</b>.
                     <br /><br />

--- a/src/components/MainFrame/Navbar.js
+++ b/src/components/MainFrame/Navbar.js
@@ -610,7 +610,9 @@ function NavBar({ triggerPreloader, theme, toggleTheme }) {
               </Tilt>
 
               <div className="floating-nav-name">{copy.displayName}</div>
-              <div className="floating-nav-title">{copy.roleTitle}</div>
+              <div className="floating-nav-title">
+                {locale === "zh" ? copy.roleTitle : <>AI Agent Engineer @ <a className="nio-link" href="https://www.nio.com/" target="_blank" rel="noopener noreferrer">NIO</a></>}
+              </div>
               <div className="floating-nav-actions">
                 <a
                   className="floating-nav-icon-btn"

--- a/src/css/style.css
+++ b/src/css/style.css
@@ -446,6 +446,14 @@ html:lang(zh) body {
     color: var(--color-text-accent) !important;
 }
 
+.nio-link,
+.nio-link:hover,
+.nio-link:focus-visible {
+    color: inherit;
+    font: inherit;
+    text-decoration: none;
+}
+
 /*================================================================
   Utilities (shared; avoid inline duplicates)
 ================================================================*/


### PR DESCRIPTION
## Summary

- Make visible NIO mentions link to the official NIO website.
- Preserve the surrounding typography and remove default link underlines.

## Why

Visitors can now open the relevant company site directly from the portfolio.

## Validation

- `npm run build`
